### PR TITLE
Fix copy to clipboard bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,7 +143,7 @@
     let resultElement = document.getElementById('result');
 
     function shorten() {
-      document.getElementById('copy-status').style.display = 'unset';
+      document.getElementById('copy-status').style.display = 'none';
       let url = urlElement.value;
 
       if (url.length < 1) {

--- a/index.html
+++ b/index.html
@@ -143,6 +143,7 @@
     let resultElement = document.getElementById('result');
 
     function shorten() {
+      document.getElementById('copy-status').style.display = 'unset';
       let url = urlElement.value;
 
       if (url.length < 1) {


### PR DESCRIPTION
Adds a `display: none;` to the `#copy-status` element when the shorten button is clicked to prevent it showing when a new URL is shortened.